### PR TITLE
Support for Multiple Payloads

### DIFF
--- a/resources/examples/multipleParameters.py
+++ b/resources/examples/multipleParameters.py
@@ -1,0 +1,17 @@
+def queueRequests(target, wordlists):
+    engine = RequestEngine(endpoint=target.endpoint,
+                           concurrentConnections=5,
+                           requestsPerConnection=100,
+                           pipeline=False
+                           )
+    engine.start()
+
+    for firstWord in open('/usr/share/dict/words'):
+      for secondWord in open('/usr/share/dict/american-english'):
+        engine.queue(target.req, [firstWord.rstrip(), secondWord.rstrip()])
+
+
+def handleResponse(req, interesting):
+    # currently available attributes are req.status, req.wordcount, req.length and req.response
+    if req.status != 404:
+        table.add(req)

--- a/src/BurpRequestEngine.kt
+++ b/src/BurpRequestEngine.kt
@@ -37,8 +37,8 @@ open class BurpRequestEngine(url: String, threads: Int, maxQueueSize: Int, overr
     }
 
 
-    override fun buildRequest(template: String, payload: String?, learnBoring: Int?): Request {
-        return Request(template.replace("Connection: keep-alive", "Connection: close"), payload, learnBoring ?: 0)
+    override fun buildRequest(template: String, payloads: List<String?>, learnBoring: Int?): Request {
+        return Request(template.replace("Connection: keep-alive", "Connection: close"), payloads, learnBoring ?: 0)
     }
 
 
@@ -64,10 +64,10 @@ open class BurpRequestEngine(url: String, threads: Int, maxQueueSize: Int, overr
             var resp = Utils.callbacks.makeHttpRequest(service, req.getRequestAsBytes())
             connections.incrementAndGet()
             while (resp.response == null && shouldRetry(req)) {
-                Utils.out("Retrying "+req.word)
+                Utils.out("Retrying "+req.words)
                 resp = Utils.callbacks.makeHttpRequest(service, req.getRequestAsBytes())
                 connections.incrementAndGet()
-                Utils.out("Retried "+req.word)
+                Utils.out("Retried "+req.words)
             }
 
             if(resp.response == null) {

--- a/src/Request.kt
+++ b/src/Request.kt
@@ -6,7 +6,7 @@ import java.util.*
 import java.util.Arrays.asList
 import kotlin.collections.HashMap
 
-open class Request(val template: String, val word: String?, val learnBoring: Int) {
+open class Request(val template: String, val words: List<String?>, val learnBoring: Int) {
 
     var response: String? = null
     var details: IResponseVariations? = null
@@ -58,14 +58,14 @@ open class Request(val template: String, val word: String?, val learnBoring: Int
         }
     }
 
-    constructor(template: String): this(template, null, 0)
+    constructor(template: String): this(template, emptyList<String>(), 0)
 
     fun getBurpRequest(): IHttpRequestResponse {
         return BurpRequest(this)
     }
 
     fun getRequest(): String {
-        if (word == null) {
+        if (words.isEmpty()) {
             return template
         }
 
@@ -73,13 +73,17 @@ open class Request(val template: String, val word: String?, val learnBoring: Int
             Utils.out("Bad base request - nowhere to inject payload")
         }
 
-        val req = template.replace("%s", word)
+        var req = template
+
+        for (w in words){
+            req = req.replaceFirst("%s", w.toString(), false)
+        }
 
         if (req.contains("%s")) {
             Utils.out("Bad base request - contains too many %s")
         }
 
-        return template.replace("%s", word)
+        return req
     }
 
     fun getRequestAsBytes(): ByteArray {

--- a/src/RequestEngine.kt
+++ b/src/RequestEngine.kt
@@ -37,19 +37,19 @@ abstract class RequestEngine {
 
     abstract fun start(timeout: Int = 10)
 
-    abstract fun buildRequest(template: String, payload: String?, learnBoring: Int?): Request
+    abstract fun buildRequest(template: String, payloads: List<String?>, learnBoring: Int?): Request
 
     fun queue(req: String) {
-        queue(req, null, 0, null)
+        queue(req, emptyList<String>(), 0, null)
     }
 
-    fun queue(template: String, payload: String?) {
-        queue(template, payload, 0, null)
+    fun queue(template: String, payloads:  List<String?>) {
+        queue(template, payloads, 0, null)
     }
 
-    fun queue(template: String, payload: String?, learnBoring: Int?, callback: ((Request, Boolean) -> Boolean)?) {
+    fun queue(template: String, payloads: List<String?>, learnBoring: Int?, callback: ((Request, Boolean) -> Boolean)?) {
 
-        if (payload != null && !template.contains("%s")) {
+        if (!payloads.isEmpty() && !template.contains("%s")) {
             Utils.out("Add %s to the request where you want the payload to go.")
             throw Exception("Add %s to the request where you want the payload to go.")
         }
@@ -58,7 +58,7 @@ abstract class RequestEngine {
             throw Exception("Automatic interesting response detection using 'learn=X' isn't support in command line mode.")
         }
 
-        val request = buildRequest(template, payload, learnBoring)
+        val request = buildRequest(template, payloads, learnBoring)
         request.engine = this
         request.callback = callback
 
@@ -133,7 +133,7 @@ abstract class RequestEngine {
     fun statusString(): String {
         val duration = Math.ceil(((System.nanoTime().toFloat() - start) / 1000000000).toDouble()).toInt()
         val requests = successfulRequests.get().toFloat()
-        var statusString = String.format("Reqs: %d | Queued: %d | Duration: %d |RPS: %.0f | Connections: %d | Retries: %d | Fails: %d | Next: %s", requests.toInt(), requestQueue.count(), duration, requests / duration, connections.get(), retries.get(), permaFails.get(), requestQueue.peek()?.word?: "")
+        var statusString = String.format("Reqs: %d | Queued: %d | Duration: %d |RPS: %.0f | Connections: %d | Retries: %d | Fails: %d | Next: %s", requests.toInt(), requestQueue.count(), duration, requests / duration, connections.get(), retries.get(), permaFails.get(), requestQueue.peek().words.joinToString(separator="/"))
         val state = attackState.get()
         if (state < 3) {
             return statusString
@@ -219,7 +219,7 @@ abstract class RequestEngine {
             return false
         }
 
-        val reqID = req.word ?: req.getRequest().hashCode().toString()
+        val reqID = req.getRequest().hashCode().toString()
 
         val fails = failedWords.get(reqID)
         if (fails == null){

--- a/src/RequestEngine.kt
+++ b/src/RequestEngine.kt
@@ -49,9 +49,14 @@ abstract class RequestEngine {
 
     fun queue(template: String, payloads: List<String?>, learnBoring: Int?, callback: ((Request, Boolean) -> Boolean)?) {
 
-        if (!payloads.isEmpty() && !template.contains("%s")) {
+        if (!template.contains("%s")) {
             Utils.out("Add %s to the request where you want the payload to go.")
             throw Exception("Add %s to the request where you want the payload to go.")
+        }
+
+        if ((payloads.isEmpty()) || (payloads.size == 1 && payloads[0] == null)) {
+            Utils.out("Add payloads to send requests")
+            throw Exception("Add payloads to send requests")
         }
 
         if (learnBoring != 0 && !Utils.gotBurp) {

--- a/src/RequestTable.kt
+++ b/src/RequestTable.kt
@@ -39,7 +39,7 @@ class ConsolePrinter: OutputHandler {
     }
 
     override fun add(req: Request) {
-        Utils.out(String.format("%s | %s | %s | %s | %s ", requestID.incrementAndGet(), req.word?: "", req.code, req.wordcount, req.length))
+        Utils.out(String.format("%s | %s | %s | %s | %s ", requestID.incrementAndGet(), req.words.joinToString(separator="/"), req.code, req.wordcount, req.length))
     }
 }
 

--- a/src/RequestTableModel.kt
+++ b/src/RequestTableModel.kt
@@ -35,7 +35,7 @@ class RequestTableModel : AbstractTableModel() {
 
         return when (columnIndex) {
             0 -> rowIndex
-            1 -> request.word
+            1 -> request.words.joinToString(separator="/")
             2 ->  request.code
             3 -> request.wordcount
             4 -> request.length

--- a/src/ThreadedRequestEngine.kt
+++ b/src/ThreadedRequestEngine.kt
@@ -59,8 +59,8 @@ open class ThreadedRequestEngine(url: String, val threads: Int, maxQueueSize: In
         start = System.nanoTime()
     }
 
-    override fun buildRequest(template: String, payload: String?, learnBoring: Int?): Request {
-        return Request(template.replace("Connection: close", "Connection: keep-alive"), payload, learnBoring ?: 0)
+    override fun buildRequest(template: String, payloads: List<String?>, learnBoring: Int?): Request {
+        return Request(template.replace("Connection: close", "Connection: keep-alive"), payloads, learnBoring ?: 0)
     }
 
     private fun sendRequests(url: URL, trustingSslSocketFactory: SSLSocketFactory, ipAddress: InetAddress?, port: Int, retryQueue: LinkedBlockingQueue<Request>, completedLatch: CountDownLatch, baseReadFreq: Int, baseRequestsPerConnection: Int, connectedLatch: CountDownLatch) {
@@ -272,10 +272,10 @@ open class ThreadedRequestEngine(url: String, val threads: Int, maxQueueSize: In
                     // todo distinguish couldn't send vs couldn't read
                     val activeRequest = inflight.peek()
                     if (activeRequest != null) {
-                        val activeWord = activeRequest.word ?: "(null)"
+                        val activeWord = activeRequest.words.joinToString(separator="/")
                         if (shouldRetry(activeRequest)) {
                             if (reqWithResponse != null) {
-                                Utils.out("Autorecovering error after " + answeredRequests + " answered requests. After '" + reqWithResponse.word + "' during '" + activeWord + "'")
+                                Utils.out("Autorecovering error after " + answeredRequests + " answered requests. After '" + reqWithResponse.words.joinToString(separator="/") + "' during '" + activeWord + "'")
                             } else {
                                 Utils.out("Autorecovering first-request error during '" + activeWord + "'")
                             }

--- a/src/fast-http.kt
+++ b/src/fast-http.kt
@@ -64,9 +64,8 @@ class RequestEngine:
 
 
     def queue(self, template, payloads=None, learn=None, callback=None):
-        if payloads != None:
-            if(not isinstance(payloads, list)):
-                payloads = [payloads]
+        if(not isinstance(payloads, list)):
+            payloads = [payloads]
         self.engine.queue(template, payloads, learn, callback)
 
 

--- a/src/fast-http.kt
+++ b/src/fast-http.kt
@@ -63,11 +63,11 @@ class RequestEngine:
         self.engine.setOutput(outputHandler)
 
 
-    def queue(self, template, payload=None, learn=None, callback=None):
-        if payload != None:
-            if(not isinstance(payload, basestring)):
-                payload = str(payload)
-        self.engine.queue(template, payload, learn, callback)
+    def queue(self, template, payloads=None, learn=None, callback=None):
+        if payloads != None:
+            if(not isinstance(payloads, list)):
+                payloads = [payloads]
+        self.engine.queue(template, payloads, learn, callback)
 
 
     def start(self, timeout=5):
@@ -178,6 +178,7 @@ class TurboIntruderFrame(inputRequest: IHttpRequestResponse, val selectionBounds
             } else {
                 messageEditor.setMessage(req.request, true)
             }
+
 
             val defaultScript = Utils.callbacks.loadExtensionSetting("defaultScript")
             if (defaultScript == null){


### PR DESCRIPTION
Added the ability to use multiple payloads. This is done by the user passing in a list instead of just one parameter. Passing in a single payload still works. 

The occurrences of the payload in the UI are now joined together with the "/" character. This could definitely be improved upon.

I'd like to be able to get the table to size dynamically depending on the number of payloads. 

 