### PR TITLE
Fix line ending in text editor

### DIFF
--- a/src/Request.kt
+++ b/src/Request.kt
@@ -139,7 +139,7 @@ open class Request(val template: String, val words: List<String?>, val learnBori
 
             while (i < end && request[i++] != ' '.toByte()) {
             }
-            val header_name = Arrays.copyOfRange(request, line_start, i - 2)
+            val header_name = request.copyOfRange(line_start, i - 2)
             val headerValueStart = i
             while (i < end && request[i++] != '\n'.toByte()) {
             }

--- a/src/fast-http.kt
+++ b/src/fast-http.kt
@@ -388,7 +388,10 @@ class TurboIntruderFrame(inputRequest: IHttpRequestResponse, val selectionBounds
                             requestPanel.add(requestTable, BorderLayout.CENTER)
                             requestPanel.add(button, BorderLayout.SOUTH)
                             pane.bottomComponent = requestPanel
-                            val script = textEditor.text
+                            var script = textEditor.text
+                            if(!script.contains("\r\n")) {
+                                script = script.replace("\n", "\r\n")
+                            }
                             Utils.callbacks.saveExtensionSetting("defaultScript", script)
                             Utils.callbacks.helpers
                             val baseRequest = Utils.callbacks.helpers.bytesToString(messageEditor.message)


### PR DESCRIPTION
Writing requests in the Python script editor results in an incorrect offset in the Content-Lenght header, which in turn is sent incorrectly to the server.
This simple fix addresses this issue.