### PR TITLE
Changes allowing `master` to be compiled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ task fatJar(type: Jar) {
                 'Main-Class': 'burp.Fast_httpKt'
         )
     }
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     baseName = project.name + '-all'
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar

--- a/src/BurpRequestEngine.kt
+++ b/src/BurpRequestEngine.kt
@@ -54,7 +54,7 @@ open class BurpRequestEngine(url: String, threads: Int, maxQueueSize: Int, overr
         var resp: IHttpRequestResponse? = null
         if (supportsHTTP2) {
             try {
-                resp = Utils.callbacks.makeHttpRequest(service, req.getRequestAsBytes(), forceHTTP1)
+                resp = Utils.callbacks.makeHttpRequest(service, req.getRequestAsBytes())
             } catch (e: NoSuchMethodError) {
                 supportsHTTP2 = false
             }


### PR DESCRIPTION
I am trying to run bleeding-edge on this repo and there are a couple of compile-time errors that prevent the build from succeeding.

### Proviso:

I am not a Java/Kotlin developer and I do not know the direction of this project; I merely wanted to compile my own and not run the version on BApps.

### Error the First:
```
turbo-intruder\src\BurpRequestEngine.kt: (57, 40): None of the following functions can be called with the arguments supplied:
public abstract fun makeHttpRequest(p0: IHttpService!, p1: ByteArray!): IHttpRequestResponse! defined in burp.IBurpExtenderCallbacks
public abstract fun makeHttpRequest(p0: String!, p1: Int, p2: Boolean, p3: ByteArray!): ByteArray! defined in burp.IBurpExtenderCallbacks
```
I could not find the documentation for the `makeHttpRequest` library, but the error reflects that a third parameter is not permitted. - erased `..., forceHTTP1)`

### Error the Second:
```
Execution failed for task ':fatJar'.
> Entry META-INF/LICENSE is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/7.0/dsl/org.gradle.api.file.CopySpec.html#org.gradle.api.file.CopySpec:duplicatesStrategy for details. 
```

Turns out there is a [known issue ](https://youtrack.jetbrains.com/issue/KT-46165) with `gradle 7` where there is no duplicate strategy and instead of a `WARN` it causes a `fail`.

Followed [this guide](https://docs.gradle.org/current/userguide/upgrading_version_5.html#implicit_duplicate_strategy_for_copy_or_archive_tasks_has_been_deprecated) that simply required:
```
duplicatesStrategy = DuplicatesStrategy.INCLUDE
```
 
To the `build.gradle` file.

### Thank You ...

For this. It's been helpful to many, and I hope this contribution is helpful to others!

### Log dump of all files and errors

<details><summary>Click here to view. It's kinda long.</summary><p>

```
PS G:\Users\person\Documents\Git\turbo-intruder> gradle --version

------------------------------------------------------------
Gradle 7.0
------------------------------------------------------------

Build time:   2021-04-09 22:27:31 UTC
Revision:     d5661e3f0e07a8caff705f1badf79fb5df8022c4

Kotlin:       1.4.31
Groovy:       3.0.7
Ant:          Apache Ant(TM) version 1.10.9 compiled on September 27 2020
JVM:          1.8.0_242-release (JetBrains s.r.o 25.242-b01)
OS:           Windows 10 10.0 amd64

PS G:\Users\person\Documents\Git\turbo-intruder> gradle build fatJar
> Task :compileKotlin FAILED
e: G:\Users\person\Documents\Git\turbo-intruder\src\BurpRequestEngine.kt: (57, 40): None of the following functions can be called with the arguments supplied:
public abstract fun makeHttpRequest(p0: IHttpService!, p1: ByteArray!): IHttpRequestResponse! defined in burp.IBurpExtenderCallbacks
public abstract fun makeHttpRequest(p0: String!, p1: Int, p2: Boolean, p3: ByteArray!): ByteArray! defined in burp.IBurpExtenderCallbacks

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileKotlin'.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/7.0/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 3s
1 actionable task: 1 executed
PS G:\Users\person\Documents\Git\turbo-intruder> git stash apply 0
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)

no changes added to commit (use "git add" and/or "git commit -a")
PS G:\Users\person\Documents\Git\turbo-intruder> git diff
diff --git a/src/BurpRequestEngine.kt b/src/BurpRequestEngine.kt
index 0dfa715..ae7627d 100644
--- a/src/BurpRequestEngine.kt
+++ b/src/BurpRequestEngine.kt
@@ -54,7 +54,7 @@ open class BurpRequestEngine(url: String, threads: Int, maxQueueSize: Int, overr
         var resp: IHttpRequestResponse? = null
         if (supportsHTTP2) {
-                resp = Utils.callbacks.makeHttpRequest(service, req.getRequestAsBytes(), forceHTTP1)
+                resp = Utils.callbacks.makeHttpRequest(service, req.getRequestAsBytes())
             } catch (e: NoSuchMethodError) {
                 supportsHTTP2 = false
             }
PS G:\Users\person\Documents\Git\turbo-intruder> gradle build fatJar
> Task :fatJar FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':fatJar'.
dle.api.file.CopySpec:duplicatesStrategy for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/7.0/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 19s
6 actionable tasks: 6 executed
PS G:\Users\person\Documents\Git\turbo-intruder> git stash apply 1
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   build.gradle
        modified:   src/BurpRequestEngine.kt

no changes added to commit (use "git add" and/or "git commit -a")
PS G:\Users\person\Documents\Git\turbo-intruder> git diff .\build.gradle
diff --git a/build.gradle b/build.gradle
index 3dae83e..f6d541d 100644
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ task fatJar(type: Jar) {
                 'Main-Class': 'burp.Fast_httpKt'
         )
     }
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     baseName = project.name + '-all'
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
PS G:\Users\person\Documents\Git\turbo-intruder> gradle build fatJar

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/7.0/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 6s
6 actionable tasks: 1 executed, 5 up-to-date
PS G:\Users\person\Documents\Git\turbo-intruder>
```

</p></details>
