### PR TITLE
pauseBefore Bug Fix

### DIFF
--- a/src/ThreadedRequestEngine.kt
+++ b/src/ThreadedRequestEngine.kt
@@ -223,7 +223,7 @@ open class ThreadedRequestEngine(url: String, val threads: Int, maxQueueSize: In
                             if (req.pauseBefore < 0) {
                                 end = byteReq.size + req.pauseBefore
                             } else {
-                                end = req.pauseBefore - 1 // since it's 0-indexed
+                                end = req.pauseBefore
                             }
                             val part1 = byteReq.sliceArray(0 until end)
                             //Utils.out("'"+Utilities.helpers.bytesToString(part1)+"'")


### PR DESCRIPTION
PR associated with #109.

If pauseBefore is a positive value, this will set the correct position to pause. Currently the pause point is off by 1 character when using pauseBefore.

The sliceArray function includes `end`, which allows users to specify exactly up to and including the location to pause.