### PR TITLE
Add "Run script" navbar element and host/port/protocol UI elements

### DIFF
--- a/src/BurpExtender.kt
+++ b/src/BurpExtender.kt
@@ -7,6 +7,10 @@ import burp.api.montoya.ui.contextmenu.ContextMenuItemsProvider
 import java.awt.Component
 import javax.swing.JMenuItem
 import javax.swing.SwingUtilities
+import javax.swing.JFrame
+import burp.api.montoya.ui.menu.BasicMenuItem
+import burp.api.montoya.ui.menu.Menu
+import burp.api.montoya.ui.menu.MenuBar
 
 class BurpExtender() : IBurpExtender, IExtensionStateListener, BurpExtension {
 
@@ -30,10 +34,45 @@ class BurpExtender() : IBurpExtender, IExtensionStateListener, BurpExtension {
         Utilities.globalSettings.registerSetting("learn observed words", false);
 
         SwingUtilities.invokeLater(ConfigMenu())
+        SwingUtilities.invokeLater { addRunScriptToExistingMenu() }
     }
 
     override fun initialize(montoyaApi: MontoyaApi) {
         Utils.montoyaApi = montoyaApi
         montoyaApi.userInterface().registerContextMenuItemsProvider(BulkMenu())
+
+        // Keep Montoya registrations minimal to avoid duplicating the existing top-level menu
+    }
+
+    // ConfigurableSettings.java in albinowaxUtils inits a default Settings menu, let's find it and add more items to it
+    private fun addRunScriptToExistingMenu() {
+        val burpFrame = java.awt.Frame.getFrames().firstOrNull { it.isVisible && it.title.startsWith("Burp Suite") }
+        if (burpFrame is JFrame) {
+            val menuBar = burpFrame.jMenuBar ?: return
+            for (i in 0 until menuBar.menuCount) {
+                val menu = menuBar.getMenu(i) ?: continue
+                if (menu.text == "Turbo Intruder") {
+                    val runItem = JMenuItem("Run script")
+                    runItem.addActionListener {
+                        try {
+                            val helpers = Utils.callbacks.helpers
+                            val host = "example.com"
+                            val port = 443
+                            val protocol = "https"
+                            val service = helpers.buildHttpService(host, port, protocol)
+                            val raw = Scripts.DEFAULT_RAW_REQUEST.toByteArray(Charsets.ISO_8859_1)
+                            val stub = StubRequest(raw, service)
+                            TurboIntruderFrame(stub, IntArray(0), Scripts.SAMPLEBURPSCRIPT, raw, null).actionPerformed(null)
+                        } catch (e: Exception) {
+                            Utils.out("Failed to open Turbo Intruder: " + (e.message ?: e.toString()))
+                        }
+                    }
+                    menu.add(runItem)
+                    menu.revalidate()
+                    menu.repaint()
+                    break
+                }
+            }
+        }
     }
 }

--- a/src/fast-http.kt
+++ b/src/fast-http.kt
@@ -25,7 +25,9 @@ import kotlin.concurrent.thread
 class Scripts() {
     companion object {
         val SCRIPTENVIRONMENT = Scripts::class.java.getResource("/ScriptEnvironment.py").readText()
-        val DEFAULT_RAW_REQUEST: String = listOf(
+        val SAMPLEBURPSCRIPT = Scripts::class.java.getResource("/examples/default.py").readText()
+
+         val DEFAULT_RAW_REQUEST: String = listOf(
             "GET / HTTP/1.1",
             "Host: example.com",
             "Cache-Control: max-age=0",
@@ -44,27 +46,6 @@ class Scripts() {
             "",
             ""
         ).joinToString("\r\n")
-
-        val SAMPLEBURPSCRIPT: String = """
-            def queueRequests(target, wordlists):
-                engine = RequestEngine(endpoint=target.endpoint,
-                                       concurrentConnections=10,
-                                       requestsPerConnection=1,
-                                       pipeline=False
-                                       )
-
-                # engine.engine.applySetting('ignoreLength', True)
-
-                # send 100 requests
-                for word in range(0, 100):
-                    engine.queue(target.req)
-
-
-            def handleResponse(req, interesting):
-                # currently available attributes are req.status, req.wordcount, req.length and req.response
-                if req.status != 99999:
-                    table.add(req)
-        """.trimIndent()
     }
 }
 


### PR DESCRIPTION
Hi team,

This PR introduces a quality-of-life improvement for Turbo Intruder. It allows users to launch scans faster without needing to configure a Repeater tab first.

## What’s new

- Added a “Run Scan” option to the Burp Suite navbar, enabling Turbo Intruder to be launched from anywhere:
<img width="450" height="200" alt="image" src="https://github.com/user-attachments/assets/273466f4-77d5-41b7-8157-7306bb30e621" />

- Opening it brings up the familiar Turbo Intruder UI:
<img width="2330" height="1606" alt="image" src="https://github.com/user-attachments/assets/441618f8-c4a2-4f8b-8037-a53ef233c68e" />

- New default fields for host, port, and protocol are included. These are pre-populated but editable.

- When using “Send to Turbo Intruder,” these UI elements are automatically set to the correct values. Users can still adjust them if needed.

This update should make it quicker and more convenient to run scans directly within Burp Suite.

Hope this helps!