### PR TITLE
Added Example Scripts

### DIFF
--- a/resources/examples/(Tuning) - CuncurrentRequests.py
+++ b/resources/examples/(Tuning) - CuncurrentRequests.py
@@ -1,0 +1,25 @@
+USER_FILE = "E:\\Apps\\SecLists-2025.1\\Usernames\\top-usernames-shortlist.txt"   # <-- set your path (use forward slashes or double backslash)
+PASS_FILE = "E:\\Apps\\SecLists-2025.1\\Usernames\\top-usernames-shortlist.txt"    # <-- set your path
+
+def load_lines(path):
+    try:
+        p = path.replace("\\", "/")
+        f = open(p, "r")
+        lines = [l.rstrip() for l in f.readlines() if l.rstrip()]
+        f.close()
+        return lines
+    except Exception as e:
+        print("ERROR opening %s : %s" % (path, str(e)))
+        return []
+
+def count_combos():
+    users = load_lines(USER_FILE)
+    passes = load_lines(PASS_FILE)
+    u = len(users)
+    p = len(passes)
+    combos = u * p
+    print("Users: %d, Passwords: %d, Combos: %d" % (u, p, combos))
+    return u, p, combos
+
+# run when script is loaded
+count_combos()

--- a/resources/examples/Example - Introder.py
+++ b/resources/examples/Example - Introder.py
@@ -1,0 +1,21 @@
+# Turbo Intruder — Introder
+
+WORDLIST = "D:\\Applications\\Wordlists\\SecLists-master\\Usernames\\top-usernames-shortlist.txt"   # <-- set your path (use forward slashes or double backslash)
+
+def load_lines(p):
+    return [l.rstrip() for l in open(p.replace("\\","/"), "r").readlines() if l.rstrip()]
+
+def queueRequests(target, wordlists):
+    engine = RequestEngine(endpoint=target.endpoint,
+                            autoStart=True,           # I tested it with different values, let it be autoStart
+                            concurrentConnections=40, # Modify Based on your list length
+                            requestsPerConnection=1,  # Modify Based on your list length
+                            pipeline=False)
+    words = load_lines(WORDLIST);
+
+    for w in words:
+        engine.queue(target.req, w, gate="g1")   # queue with gate name
+    engine.openGate("g1")
+    
+def handleResponse(req, interesting):
+    table.add(req)

--- a/resources/examples/Fuzzer - CL.py
+++ b/resources/examples/Fuzzer - CL.py
@@ -1,0 +1,31 @@
+# Content-Length Brute Force
+def queueRequests(target, wordlists):
+    engine = RequestEngine(endpoint=target.endpoint,
+                           concurrentConnections=10,
+                           requestsPerConnection=1,
+                           pipeline=False)
+
+    base = target.req
+    parts = base.split("\r\n\r\n", 1)
+    headers = parts[0].split("\r\n")
+    body = parts[1] if len(parts) > 1 else ""
+
+    # replace existing Content-Length line with an injection marker, or add it
+    found = False
+    for i in range(len(headers)):
+        if headers[i].lower().startswith("content-length:"):
+            headers[i] = "Content-Length: %s"
+            found = True
+            break
+    if not found:
+        headers.append("Content-Length: %s")
+
+    template = "\r\n".join(headers) + "\r\n\r\n" + body
+
+    # queue requests: Turbo Intruder will replace %s with each payload value
+    for n in range(1746, 1801):
+        engine.queue(template, str(n),fixContentLength=False)
+
+
+def handleResponse(req, interesting):
+    table.add(req)

--- a/resources/examples/Fuzzer - Clustered Bomb (v5).py
+++ b/resources/examples/Fuzzer - Clustered Bomb (v5).py
@@ -1,0 +1,35 @@
+
+USER_FILE = "D:\\Applications\\Wordlists\\SecLists-master\\Usernames\\top-usernames-shortlist.txt"   # <-- set your path (use forward slashes or double backslash)
+PASS_FILE = "D:\\Applications\\Wordlists\\SecLists-master\\Usernames\\top-usernames-shortlist.txt"    # <-- set your path
+BATCH = 289   # برابر است با تعداد درخواست هایی که میخوای یکچا بفرستی
+# مقدار BATCH باید برابر باشد با concurrentConnections
+
+def load_lines(p):
+    return [l.rstrip() for l in open(p.replace("\\","/"), "r").readlines() if l.rstrip()]
+
+def queueRequests(target, wordlists):
+    engine = RequestEngine(endpoint=target.endpoint,
+                            engine=Engine.Burp2
+                            autoStart=False,
+                            concurrentConnections=BATCH,
+                            requestsPerConnection=1,
+                            pipeline=False)
+    base = target.req
+    if "__USER__" not in base or "__PASS__" not in base:
+        print("Put __USER__ and __PASS__ in request"); return
+    
+    template = base.replace("__USER__","%s").replace("__PASS__","%s")
+
+    users = load_lines(USER_FILE);
+    pwds = load_lines(PASS_FILE)
+    
+    engine.start()
+    for u in users:
+        for p in pwds:    
+            engine.queue(template, [u, p], gate="g1")   # queue with gate name
+
+    engine.openGate("g1")
+    
+
+def handleResponse(req, interesting):
+    table.add(req)

--- a/resources/examples/Fuzzer - Smuggled CL.py
+++ b/resources/examples/Fuzzer - Smuggled CL.py
@@ -1,0 +1,30 @@
+# Turbo Intruder — replace Content-Length of the SECOND request and test 1746..1800
+def queueRequests(target, wordlists):
+    engine = RequestEngine(endpoint=target.endpoint, concurrentConnections=10, requestsPerConnection=1, pipeline=False)
+
+    base = target.req
+    # split first request / remainder (which contains request 2)
+    first, rest = base.split("\r\n\r\n", 1)
+    # split headers and body of request 2
+    h2, b2 = rest.split("\r\n\r\n", 1)
+
+    # replace Content-Length in request 2 headers (or add if missing)
+    lines = h2.split("\r\n")
+    found = False
+    for i in range(len(lines)):
+        if lines[i].lower().startswith("content-length:"):
+            lines[i] = "Content-Length: %s"
+            found = True
+            break
+    if not found:
+        lines.append("Content-Length: %s")
+
+    h2_mod = "\r\n".join(lines)
+    template = first + "\r\n\r\n" + h2_mod + "\r\n\r\n" + b2
+
+    for n in range(1746, 1801):
+        engine.queue(template, str(n))
+
+
+def handleResponse(req, interesting):
+    table.add(req)

--- a/resources/examples/Fuzzer - Wordlist Folder.py
+++ b/resources/examples/Fuzzer - Wordlist Folder.py
@@ -1,0 +1,93 @@
+# Turbo Intruder — one gate per file, safe sub-batching to avoid deadlock
+import os
+from time import sleep
+
+WORDLIST_DIR = "D:\\Research\\Notes\\race conditions\\wordlist"    # <-- folder with files
+CONNECTIONS = 100            # concurrentConnections (tune)
+REQ_PER_CONNECTION = 40     # Request per connections (tune)
+HTTP_PIPE_LINE = True # Tune
+DELAY_AFTER_START = 0.1     #  (tune)
+DELAY_BETWEEN_GATES = 0.1      #  (tune)
+
+def load_lines(fp):
+    out = []
+    try:
+        f = open(fp, "r")
+        for line in f:
+            v = line.rstrip()
+            if v:
+                out.append(v)
+        f.close()
+    except:
+        pass
+    return out
+
+def queueRequests(target, wordlists):
+    engine = RequestEngine(endpoint=target.endpoint,
+                           autoStart=False,
+                           concurrentConnections=CONNECTIONS,
+                           requestsPerConnection=REQ_PER_CONNECTION,
+                           pipeline=HTTP_PIPE_LINE)
+
+    base = target.req
+    if "__PAYLOAD__" not in base:
+        print("ERROR: put __PAYLOAD__ in request"); return
+    template = base.replace("__PAYLOAD__", "%s")
+
+    d = WORDLIST_DIR.replace("\\", "/")
+    try:
+        names = sorted(os.listdir(d))
+    except Exception as e:
+        print("ERROR reading folder:", str(e)); return
+
+    # start engine once
+    try:
+        engine.start()
+    except:
+        pass
+    sleep(DELAY_AFTER_START)
+
+    total = 0
+    file_index = 0
+
+    for name in names:
+        fp = d + "/" + name
+        if not os.path.isfile(fp):
+            continue
+        payloads = load_lines(fp)
+        if not payloads:
+            continue
+        file_index += 1
+
+        # process this file in sub-batches sized <= CONCURRENCY
+        start = 0
+        part = 0
+        while start < len(payloads):
+            part += 1
+            end = start + CONNECTIONS
+            chunk = payloads[start:end]
+            gid = "f%d_p%d" % (file_index, part)   # string gate id
+
+            # queue this chunk under gid
+            for p in chunk:
+                try:
+                    engine.queue(template, p, gate=str(gid))
+                    total += 1
+                except Exception as e:
+                    print("queue error:", str(e)); return
+
+            # open this gid immediately so we don't accumulate too many gated requests
+            try:
+                engine.openGate(gid)
+            except Exception:
+                try:
+                    engine.openGate(str(gid))
+                except:
+                    print("openGate failed for", gid)
+            sleep(DELAY_BETWEEN_GATES)
+
+            start = end
+
+    print("Queued and released %d payloads from %d files" % (total, file_index))
+def handleResponse(req, interesting):
+    table.add(req)

--- a/resources/examples/Fuzzer - XFF.py
+++ b/resources/examples/Fuzzer - XFF.py
@@ -1,0 +1,27 @@
+# It first splits the request headers. If it finds X-Forwarded-For,
+    # it replaces its value with %s; otherwise it adds the X-Forwarded-For: %s header.
+# Then it queues the template for every IP from 127.0.0.1 to 127.0.0.255.
+
+def queueRequests(target, wordlists):
+    engine = RequestEngine(endpoint=target.endpoint, concurrentConnections=10, requestsPerConnection=1, pipeline=False)
+    base = target.req
+    parts = base.split("\r\n\r\n", 1)
+    headers = parts[0].split("\r\n")
+    body = parts[1] if len(parts) > 1 else ""
+
+    found = False
+    for i in range(len(headers)):
+        if headers[i].lower().startswith("x-forwarded-for:"):
+            headers[i] = "X-Forwarded-For: %s"
+            found = True
+            break
+    if not found:
+        headers.append("X-Forwarded-For: %s")
+
+    template = "\r\n".join(headers) + "\r\n\r\n" + body
+    for n in range(1, 256):
+        engine.queue(template, "127.0.0.%d" % n)
+
+
+def handleResponse(req, _):
+    table.add(req)


### PR DESCRIPTION
Adds multiple example scripts demonstrating common Turbo Intruder patterns:

1. **Fuzzer - Wordlist Folder.py**
  Read every file in a folder and use each line as a payload for a single placeholder `__PAYLOAD__`. A gate for each file.

2. **Fuzzer - Clustered Bomb (v5).py**
  Clustered-bomb style script: reads `usernames.txt` and `passwords.txt`, builds all user×pass combos and queues them (engine.queue(template, [user, pass])). Tunable concurrency and max combos.

3. **Fuzzer - CL.py**
  Replace `Content-Length` in the request template with values in a numeric range (e.g. `1746..1800`) and queue/send them.

4. **Fuzzer - Smuggled CL.py**
  For requests that contain two POSTs back-to-back: replace the **second** request’s `Content-Length` with `%s` and test a numeric range.

5. **Fuzzer - XFF.py**
  Turbo Intruder script that replaces `X-Forwarded-For` with `127.0.0.1` → `127.0.0.255` and queues requests.

6. **(Tuning) - CuncurrentRequests.py**
  Small test script that queues a tiny hard-coded set of combos (useful to verify Turbo Intruder environment works before large runs).

Main Repository: https://github.com/MasoudAbdaal/Turbo-Introder-Scripts